### PR TITLE
[Enhancement] Add methods to bulk insert or remove policies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ service:
 
 before_install:
   - echo $TRAVIS_GO_VERSION
-  - go install github.com/mattn/goveralls@latest
   - docker pull quay.io/coreos/etcd:v3.3.10
   - docker run -d -p 2379:2379 quay.io/coreos/etcd:v3.3.10 etcd --name test-etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://0.0.0.0:2379
 
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci
+  - go test -cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ service:
 
 before_install:
   - echo $TRAVIS_GO_VERSION
-  - go get github.com/mattn/goveralls
+  - go install github.com/mattn/goveralls@latest
   - docker pull quay.io/coreos/etcd:v3.3.10
   - docker run -d -p 2379:2379 quay.io/coreos/etcd:v3.3.10 etcd --name test-etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://0.0.0.0:2379
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ before_install:
   - docker run -d -p 2379:2379 quay.io/coreos/etcd:v3.3.10 etcd --name test-etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://0.0.0.0:2379
 
 script:
+  - go vet .
   - go test -cover

--- a/adapter.go
+++ b/adapter.go
@@ -105,9 +105,6 @@ func (a *Adapter) close() {
 
 // LoadPolicy loads all of policys from ETCD
 func (a *Adapter) LoadPolicy(model model.Model) error {
-	// Emits the time required to load the policy from storage
-	defer recordOp("Loaded policy in ", time.Now())
-
 	var rule CasbinRule
 	ctx, cancel := context.WithTimeout(context.Background(), REQUESTTIMEOUT)
 	defer cancel()
@@ -425,8 +422,4 @@ func (a *Adapter) removeFilteredPolicy(filter string) error {
 		}
 	}
 	return nil
-}
-
-func recordOp(msg string, start time.Time) {
-	fmt.Printf("%s %s\n", msg, time.Since(start))
 }

--- a/adapter.go
+++ b/adapter.go
@@ -105,7 +105,8 @@ func (a *Adapter) close() {
 
 // LoadPolicy loads all of policys from ETCD
 func (a *Adapter) LoadPolicy(model model.Model) error {
-	defer recordOp("***loading policy***", time.Now())
+	// Emits the time required to load the policy from storage
+	defer recordOp("Loaded policy in ", time.Now())
 
 	var rule CasbinRule
 	ctx, cancel := context.WithTimeout(context.Background(), REQUESTTIMEOUT)
@@ -272,6 +273,7 @@ func (a *Adapter) RemovePolicy(sec string, ptype string, line []string) error {
 	return err
 }
 
+// AddPolicies adds a list of policy rules to the storage
 func (a *Adapter) AddPolicies(sec string, ptype string, rules [][]string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), REQUESTTIMEOUT)
 	defer cancel()
@@ -296,6 +298,7 @@ func (a *Adapter) AddPolicies(sec string, ptype string, rules [][]string) error 
 	return nil
 }
 
+// RemovePolicies removes a list of policy rules fro mthe storage
 func (a *Adapter) RemovePolicies(sec string, ptype string, rules [][]string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), REQUESTTIMEOUT)
 	defer cancel()

--- a/adapter.go
+++ b/adapter.go
@@ -105,6 +105,8 @@ func (a *Adapter) close() {
 
 // LoadPolicy loads all of policys from ETCD
 func (a *Adapter) LoadPolicy(model model.Model) error {
+	defer recordOp("***loading policy***", time.Now())
+
 	var rule CasbinRule
 	ctx, cancel := context.WithTimeout(context.Background(), REQUESTTIMEOUT)
 	defer cancel()
@@ -131,27 +133,35 @@ func (a *Adapter) getRootKey() string {
 }
 
 func (a *Adapter) loadPolicy(rule CasbinRule, model model.Model) {
-	lineText := rule.PType
+	var line strings.Builder
+	line.WriteString(rule.PType)
+
 	if rule.V0 != "" {
-		lineText += ", " + rule.V0
+		line.WriteString(", ")
+		line.WriteString(rule.V0)
 	}
 	if rule.V1 != "" {
-		lineText += ", " + rule.V1
+		line.WriteString(", ")
+		line.WriteString(rule.V1)
 	}
 	if rule.V2 != "" {
-		lineText += ", " + rule.V2
+		line.WriteString(", ")
+		line.WriteString(rule.V2)
 	}
 	if rule.V3 != "" {
-		lineText += ", " + rule.V3
+		line.WriteString(", ")
+		line.WriteString(rule.V3)
 	}
 	if rule.V4 != "" {
-		lineText += ", " + rule.V4
+		line.WriteString(", ")
+		line.WriteString(rule.V4)
 	}
 	if rule.V5 != "" {
-		lineText += ", " + rule.V5
+		line.WriteString(", ")
+		line.WriteString(rule.V5)
 	}
 
-	persist.LoadPolicyLine(lineText, model)
+	persist.LoadPolicyLine(line.String(), model)
 }
 
 // This will rewrite all of policies in ETCD with the current data in Casbin
@@ -365,4 +375,8 @@ func (a *Adapter) removeFilteredPolicy(filter string) error {
 		}
 	}
 	return nil
+}
+
+func recordOp(msg string, start time.Time) {
+	fmt.Printf("%s %s\n", msg, time.Since(start))
 }


### PR DESCRIPTION
The `etcd-adapter` lacked the capability to insert or delete policies in bulk. This PR addresses that by implementing `AddPolicies` and `RemovePolicies` that makes the `etcd-watcher` implement the `persist.BatchAdapter` interface in `casbin`.