### PR TITLE
🐛 fix: filters duplicate rules in batch requests

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -305,9 +305,17 @@ func (a *Adapter) AddPolicies(sec string, ptype string, rules [][]string) error 
 	ctx, cancel := context.WithTimeout(context.Background(), REQUESTTIMEOUT)
 	defer cancel()
 
-	ops := []client.Op{}
+	var ops []client.Op
+	ruleMap := make(map[string]struct{})
 
 	for _, r := range rules {
+		// Rule out duplicates from the request
+		hash := strings.Join(r, "")
+		if _, ok := ruleMap[hash]; ok {
+			continue
+		}
+		ruleMap[hash] = struct{}{}
+
 		rule := a.convertRule(ptype, r)
 		ruleData, _ := json.Marshal(rule)
 		ops = append(ops, client.OpPut(a.constructPath(rule.Key), string(ruleData)))
@@ -330,9 +338,17 @@ func (a *Adapter) RemovePolicies(sec string, ptype string, rules [][]string) err
 	ctx, cancel := context.WithTimeout(context.Background(), REQUESTTIMEOUT)
 	defer cancel()
 
-	ops := []client.Op{}
+	var ops []client.Op
+	ruleMap := make(map[string]struct{})
 
 	for _, r := range rules {
+		// Rule out duplicates from the request
+		hash := strings.Join(r, "")
+		if _, ok := ruleMap[hash]; ok {
+			continue
+		}
+		ruleMap[hash] = struct{}{}
+
 		rule := a.convertRule(ptype, r)
 		ops = append(ops, client.OpDelete(a.constructPath(rule.Key)))
 	}

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -1,6 +1,7 @@
 package etcdadapter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/casbin/casbin/v2"
@@ -104,11 +105,56 @@ func testAutoSave(t *testing.T, pathKey string, etcdEndpoints []string) {
 	e.RemoveFilteredPolicy(0, "data2_admin")
 	e.LoadPolicy()
 	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}})
+}
 
+func testBatchRequests(t *testing.T, pathKey string, etcdEndpoints []string) {
+	// Initialize some policy in ETCD.
+	initPolicy(t, pathKey, etcdEndpoints)
+	// Note: you don't need to look at the above code
+	// if you already have a working ETCD with policy inside.
+
+	// Now the ETCD has policy, so we can provide a normal use case.
+	// Create an adapter and an enforcer.
+	// NewEnforcer() will load the policy automatically.
+	a := NewAdapter(etcdEndpoints, pathKey)
+	e, _ := casbin.NewEnforcer("examples/rbac_model.conf", a)
+
+	// AutoSave is enabled by default.
+	// Now we disable it.
+	e.EnableAutoSave(true)
+
+	// Because AutoSave is disabled, the policy change only affects the policy in Casbin enforcer,
+	// it doesn't affect the policy in the storage.
+	e.AddPolicies([][]string{{"alice", "data1", "write"}})
+	// Reload the policy from the storage to see the effect.
+	e.LoadPolicy()
+	// This is still the original policy.
+	testGetPolicy(t, e, [][]string{
+		{"alice", "data1", "read"},
+		{"alice", "data1", "write"},
+		{"bob", "data2", "write"},
+		{"data2_admin", "data2", "read"},
+		{"data2_admin", "data2", "write"},
+	})
+
+	_, err := e.AddPolicies([][]string{{"alice", "data2", "write"}, {"alice", "data2", "write"}})
+
+	if err != nil && strings.Contains(err.Error(), "duplicate key given in txn request") {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	if err == nil {
+		t.Log("Test Pass")
+	}
+
+	// Remove the added rule.
+	e.RemovePolicies([][]string{{"alice", "data1", "write"}, {"alice", "data2", "write"}})
+	e.LoadPolicy()
+	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}})
 }
 
 func TestAdapters(t *testing.T) {
-
 	testSaveLoad(t, "casbin_policy_test", []string{"http://127.0.0.1:2379"})
 	testAutoSave(t, "casbin_policy_test", []string{"http://127.0.0.1:2379"})
+	testBatchRequests(t, "casbin_policy_test", []string{"http://127.0.0.1:2379"})
 }


### PR DESCRIPTION
### Description
This commit filters out duplicate rules in the incoming batch requests that leads to "duplicate key given in txn request" error.

This will help resolve these errors: https://rapyuta-robotics.sentry.io/issues/4560135465/?alert_rule_id=9237382&alert_type=issue&notification_uuid=ee4b89f9-de41-436e-b576-595977312ea5&project=6020502&referrer=slack

Wrike: https://www.wrike.com/open.htm?id=1261433387

### Testing
Manually tested the `authz` API before and after the change with the following payload.
```
curl -X POST 'http://localhost:8082/authz/subject/batchremoverole' -d '{"roleRequests":[{
    "domain":"PROJECT:project-qlpdvmzwisqiksxlefnlzonf","role":"viewer","subject":"GROUP:group-mbdxatseqkeaxbrlcvrvjyjo"},
    {"domain":"PROJECT:project-ckg2v4st3urgb6kmvj00","role":"viewer","subject":"GROUP:group-mbdxatseqkeaxbrlcvrvjyjo"},
    {"domain":"PROJECT:project-qlpdvmzwisqiksxlefnlzonf","role":"viewer","subject":"GROUP:group-mbdxatseqkeaxbrlcvrvjyjo"},
    {"domain":"PROJECT:project-ckg2v4st3urgb6kmvj00","role":"viewer","subject":"GROUP:group-mbdxatseqkeaxbrlcvrvjyjo"}]}'
```
Without the fix, the call fails with `duplicate key given in txn request` error.

With the fix, the API succeeds.